### PR TITLE
feat: use CARGO_MANIFEST_DIR to locate Cargo.toml of the current crate

### DIFF
--- a/bin/java-bindgen-macro/src/derive_into_rust.rs
+++ b/bin/java-bindgen-macro/src/derive_into_rust.rs
@@ -7,11 +7,11 @@ use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{Data, DeriveInput};
 use syn::__private::TokenStream2;
 
-use crate::util::{ts2, CompileErrors};
+use crate::util::{detect_project_dir, ts2, CompileErrors};
 
 pub fn main(item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<DeriveInput>(item.clone()) {
-        let project_dir = std::path::Path::new(".");
+        let project_dir = detect_project_dir();
         let mut errors = CompileErrors::default();
         let name = &input.ident;
 
@@ -28,7 +28,7 @@ pub fn main(item: TokenStream) -> TokenStream {
             return errors.into();
         };
 
-        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(project_dir)) {
+        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(&project_dir)) {
             store.add_ffi_class(JavaFFIClass {
                 id: name.to_string(),
                 fields: java_fields,

--- a/bin/java-bindgen-macro/src/derive_java_bindgen.rs
+++ b/bin/java-bindgen-macro/src/derive_java_bindgen.rs
@@ -12,7 +12,7 @@ use crate::{
         produce_java_args, produce_java_return, produce_rust_args_names, produce_rust_result_type,
     },
     types_conversion::rewrite_rust_type_to_jni,
-    util::{self, parse_attr_to_map, ts2, CompileErrors},
+    util::{self, detect_project_dir, parse_attr_to_map, ts2, CompileErrors},
 };
 use crate::common::BindgenReturnType;
 
@@ -155,10 +155,10 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
     if let Ok(java_fn) = syn::parse::<syn::ItemFn>(item.clone()) {
         let source = TokenStream2::from(item.clone());
         let attribute = JavaBindgenAttr::parse_attr(attr.clone());
-        let project_dir = std::path::Path::new(".");
+        let project_dir = detect_project_dir();
 
         // Parse Cargo.toml file
-        let cargo_toml = match util::parse_project_toml(project_dir) {
+        let cargo_toml = match util::parse_project_toml(&project_dir) {
             Ok(toml) => toml,
             Err(err) => {
                 let error = util::error(java_fn.span(), err.to_string());
@@ -175,7 +175,7 @@ pub fn main(attr: TokenStream, item: TokenStream) -> TokenStream {
         let return_type = produce_rust_result_type(&java_fn.sig.output, &mut errors);
 
         // Safe FFI Methods
-        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(project_dir)) {
+        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(&project_dir)) {
             let args = produce_java_args(&java_fn.sig.inputs, &mut errors);
             let return_type = attribute
                 .returns

--- a/bin/java-bindgen-macro/src/derive_java_class.rs
+++ b/bin/java-bindgen-macro/src/derive_java_class.rs
@@ -7,11 +7,11 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput};
 
-use crate::util::CompileErrors;
+use crate::util::{detect_project_dir, CompileErrors};
 
 pub fn main(item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<DeriveInput>(item.clone()) {
-        let project_dir = std::path::Path::new(".");
+        let project_dir = detect_project_dir();
         let mut errors = CompileErrors::default();
 
         // Struct Guard
@@ -21,7 +21,7 @@ pub fn main(item: TokenStream) -> TokenStream {
         };
 
         // Parse Cargo.toml file
-        let cargo_toml = match crate::util::parse_project_toml(project_dir) {
+        let cargo_toml = match crate::util::parse_project_toml(&project_dir) {
             Ok(toml) => toml,
             Err(err) => {
                 return crate::util::error(input.ident.span(), err.to_string()).into();
@@ -36,7 +36,7 @@ pub fn main(item: TokenStream) -> TokenStream {
             return errors.into();
         };
 
-        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(project_dir)) {
+        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(&project_dir)) {
             store.add_ffi_class(JavaFFIClass {
                 id: input.ident.to_string(),
                 fields: java_fields,

--- a/bin/java-bindgen-macro/src/derive_jlogger.rs
+++ b/bin/java-bindgen-macro/src/derive_jlogger.rs
@@ -1,11 +1,11 @@
-use crate::util::{self, CompileErrors};
+use crate::util::{self, detect_project_dir, CompileErrors};
 use java_bindgen_core::project_info::ProjectInfo;
 use proc_macro::TokenStream;
 use quote::quote;
 
 pub fn main(item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<syn::DeriveInput>(item.clone()) {
-        let project_dir = std::path::Path::new(".");
+        let project_dir = detect_project_dir();
         let mut errors = CompileErrors::default();
 
         // Struct Guard
@@ -15,7 +15,7 @@ pub fn main(item: TokenStream) -> TokenStream {
         };
 
         // Parse Cargo.toml file
-        let cargo_toml = match util::parse_project_toml(project_dir) {
+        let cargo_toml = match util::parse_project_toml(&project_dir) {
             Ok(toml) => toml,
             Err(err) => {
                 return util::error(input.ident.span(), err.to_string()).into();

--- a/bin/java-bindgen-macro/src/dervie_into_java.rs
+++ b/bin/java-bindgen-macro/src/dervie_into_java.rs
@@ -10,12 +10,12 @@ use syn::__private::TokenStream2;
 
 use crate::{
     common,
-    util::{self, CompileErrors},
+    util::{self, detect_project_dir, CompileErrors},
 };
 
 pub fn main(item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<DeriveInput>(item.clone()) {
-        let project_dir = std::path::Path::new(".");
+        let project_dir = detect_project_dir();
         let mut errors = CompileErrors::default();
 
         // Struct Guard
@@ -25,7 +25,7 @@ pub fn main(item: TokenStream) -> TokenStream {
         };
 
         // Parse Cargo.toml file
-        let cargo_toml = match util::parse_project_toml(project_dir) {
+        let cargo_toml = match util::parse_project_toml(&project_dir) {
             Ok(toml) => toml,
             Err(err) => {
                 return util::error(input.ident.span(), err.to_string()).into();
@@ -40,7 +40,7 @@ pub fn main(item: TokenStream) -> TokenStream {
             return errors.into();
         };
 
-        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(project_dir)) {
+        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(&project_dir)) {
             store.add_ffi_class(JavaFFIClass {
                 id: input.ident.to_string(),
                 fields: java_fields,

--- a/bin/java-bindgen-macro/src/dervie_java_type.rs
+++ b/bin/java-bindgen-macro/src/dervie_java_type.rs
@@ -8,11 +8,11 @@ use quote::quote;
 use syn::{Data, DeriveInput};
 use syn::__private::TokenStream2;
 
-use crate::util::{self, CompileErrors};
+use crate::util::{self, detect_project_dir, CompileErrors};
 
 pub fn main(item: TokenStream) -> TokenStream {
     if let Ok(input) = syn::parse::<DeriveInput>(item.clone()) {
-        let project_dir = std::path::Path::new(".");
+        let project_dir = detect_project_dir();
         let mut errors = CompileErrors::default();
 
         // Struct Guard
@@ -22,7 +22,7 @@ pub fn main(item: TokenStream) -> TokenStream {
         };
 
         // Parse Cargo.toml file
-        let cargo_toml = match util::parse_project_toml(project_dir) {
+        let cargo_toml = match util::parse_project_toml(&project_dir) {
             Ok(toml) => toml,
             Err(err) => {
                 return util::error(input.ident.span(), err.to_string()).into();
@@ -37,7 +37,7 @@ pub fn main(item: TokenStream) -> TokenStream {
             return errors.into();
         };
 
-        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(project_dir)) {
+        if let Some(mut store) = FFIStore::read_from_file(&ffi_definitions_path(&project_dir)) {
             store.add_ffi_class(JavaFFIClass {
                 id: input.ident.to_string(),
                 fields: java_fields,

--- a/bin/java-bindgen-macro/src/util.rs
+++ b/bin/java-bindgen-macro/src/util.rs
@@ -110,3 +110,9 @@ pub fn lifetime_from_type(ty: &syn::Type) -> Option<TokenStream2> {
 
     None
 }
+
+/// Detect project directory based on cargo manifest directory.
+pub fn detect_project_dir() -> std::path::PathBuf {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    std::path::PathBuf::from(&manifest_dir)
+}


### PR DESCRIPTION
Use `CARGO_MANIFEST_DIR` environment variable to detect the project directory. Enables support for crates in workspaces.